### PR TITLE
[fix] #15 HeaderNotification - Angular2 DropDowns moved into a component

### DIFF
--- a/src/client/app/components/header/header.ts
+++ b/src/client/app/components/header/header.ts
@@ -1,13 +1,14 @@
 import {Component, ElementRef} from 'angular2/core';
 import {CORE_DIRECTIVES} from 'angular2/common';
-import {Dropdown, DropdownMenu, DropdownToggle, ACCORDION_DIRECTIVES} from 'ng2-bootstrap/ng2-bootstrap';
+import {ACCORDION_DIRECTIVES} from 'ng2-bootstrap/ng2-bootstrap';
+import {DropdownDirective, DropdownMenuDirective, DropdownToggleDirective} from 'ng2-bootstrap/components/dropdown';
 
 import {ROUTER_DIRECTIVES} from 'angular2/router';
 @Component({
   selector: 'header-notification',
   templateUrl: 'app/components/header/header-notification.html',
-  directives: [Dropdown, DropdownMenu, DropdownToggle, ROUTER_DIRECTIVES, CORE_DIRECTIVES],
-  viewProviders: [Dropdown, DropdownMenu, DropdownToggle, ElementRef]
+  directives: [DropdownDirective, DropdownMenuDirective, DropdownToggleDirective, ROUTER_DIRECTIVES, CORE_DIRECTIVES],
+  viewProviders: [DropdownDirective, DropdownMenuDirective, DropdownToggleDirective, ElementRef]
 })
 export class HeaderNotification {
   toggled(open:boolean):void {


### PR DESCRIPTION
Using Node v6.1.0, NPM v3.8.8

The issues detailed at:
https://github.com/AngularShowcase/ng2-bootstrap-sbadmin/issues/15
https://github.com/AngularShowcase/ng2-bootstrap-sbadmin/issues/12

Sorry if I haven't documented this part quite right...I'm not that familiar with submitting pull requests.
