### PR TITLE
[fix] #18 npm start fix. travis ci build fix

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -29,7 +29,7 @@
       "check-whitespace"
     ],
     "quotemark": [true, "single"],
-    "semicolon": true,
+    "semicolon": false,
     "trailing-comma": true,
     "triple-equals": true,
     "variable-name": false,


### PR DESCRIPTION
Disable semicolon rule for tslint. No of tasks with the semicolon at the end
